### PR TITLE
Fix code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
-const path = require('path');
-const express = require('express');
+const path = require("path");
+const express = require("express");
 const dotenv = require("dotenv");
-const morgan = require('morgan');
-const mongoSanitize = require('express-mongo-sanitize');
-const helmet = require('helmet');
-const xssClean = require('xss-clean');
-const expressRateLimit = require('express-rate-limit');
-const hpp = require('hpp');
-const cors = require('cors');
-const lusca = require('lusca');
-require('colors');
+const morgan = require("morgan");
+const mongoSanitize = require("express-mongo-sanitize");
+const helmet = require("helmet");
+const xssClean = require("xss-clean");
+const expressRateLimit = require("express-rate-limit");
+const hpp = require("hpp");
+const cors = require("cors");
+const lusca = require("lusca");
+const session = require("express-session");
+require("colors");
 
 // Internal Imports *****************************************************
-const logger = require('./middleware/logger');
-const cookieParser = require('cookie-parser');
-const fileUpload = require('express-fileupload');
-const errorHandler = require('./middleware/error');
-const connectDB = require('./db/db');
+const logger = require("./middleware/logger");
+const cookieParser = require("cookie-parser");
+const fileUpload = require("express-fileupload");
+const errorHandler = require("./middleware/error");
+const connectDB = require("./db/db");
 
 //Load env vars *******************************************************
 // dotenv.config({path: "./config/config.env"});
@@ -24,15 +25,15 @@ dotenv.config();
 
 //Connect To DB********************************************************
 connectDB().then(() => {
-    console.log(`Connected to MongoDB`.bgGreen.bold);
+  console.log(`Connected to MongoDB`.bgGreen.bold);
 });
 
 //Router Files**********************************************************
-const bootcamps = require('./routes/bootcampsRoute');
-const courses = require('./routes/coursesRoute');
-const auth = require('./routes/authRoute');
-const users = require('./routes/usersRoute');
-const reviews = require('./routes/reviewsRoute');
+const bootcamps = require("./routes/bootcampsRoute");
+const courses = require("./routes/coursesRoute");
+const auth = require("./routes/authRoute");
+const users = require("./routes/usersRoute");
+const reviews = require("./routes/reviewsRoute");
 
 const app = express();
 
@@ -46,8 +47,8 @@ app.use(cookieParser());
 app.use(logger);
 
 //Use morgan Middleware *************************************************
-if (process.env.NODE_ENV === 'development') {
-    app.use(morgan('dev'));
+if (process.env.NODE_ENV === "development") {
+  app.use(morgan("dev"));
 }
 
 //File Uploading *******************************************************
@@ -64,8 +65,8 @@ app.use(xssClean());
 
 //Rate Limiting ******************************************************
 const limiter = expressRateLimit({
-    windowMs: 10 * 60 * 1000, // 10 minutes
-    max: 100
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 100,
 });
 app.use(limiter);
 
@@ -75,22 +76,32 @@ app.use(hpp());
 //Enable CORS ********************************************************
 app.use(cors());
 
+// Set up session middleware
+app.use(
+  session({
+    secret: "your-secret-key",
+    resave: false,
+    saveUninitialized: true,
+    cookie: { secure: true },
+  })
+);
+
 // CSRF Protection *****************************************************
 app.use(lusca.csrf());
 
 //Set Static Folder ****************************************************
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, "public")));
 
 // Home Page
-app.get('/', (req, res) => {
-    res.send('<h1>Bootcamp Home Page</h1>');
-})
+app.get("/", (req, res) => {
+  res.send("<h1>Bootcamp Home Page</h1>");
+});
 //Mount Routers *********************************************************
-app.use('/api/v1/bootcamps', bootcamps);
-app.use('/api/v1/courses', courses);
-app.use('/api/v1/auth', auth);
-app.use('/api/v1/users', users);
-app.use('/api/v1/reviews', reviews);
+app.use("/api/v1/bootcamps", bootcamps);
+app.use("/api/v1/courses", courses);
+app.use("/api/v1/auth", auth);
+app.use("/api/v1/users", users);
+app.use("/api/v1/reviews", reviews);
 
 //Add Error Handler *****************************************************
 app.use(errorHandler);
@@ -98,15 +109,18 @@ app.use(errorHandler);
 const PORT = process.env.PORT || 5000;
 
 const server = app.listen(PORT, () => {
-    console.log(`Server Running in ${process.env.NODE_ENV} Mode on Port ${PORT}`.green.bold.inverse)
-})
+  console.log(
+    `Server Running in ${process.env.NODE_ENV} Mode on Port ${PORT}`.green.bold
+      .inverse
+  );
+});
 
 //handle unhandled promise rejections ************************************
-process.on('unhandledRejection', (error) => {
-    console.log(`Error: ${error.message}`.bgRed.bold);
+process.on("unhandledRejection", (error) => {
+  console.log(`Error: ${error.message}`.bgRed.bold);
 
-//  Close server and exit process *****************************************
-    server.close(() => {
-        process.exit(1);
-    })
-})
+  //  Close server and exit process *****************************************
+  server.close(() => {
+    process.exit(1);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const xssClean = require('xss-clean');
 const expressRateLimit = require('express-rate-limit');
 const hpp = require('hpp');
 const cors = require('cors');
+const lusca = require('lusca');
 require('colors');
 
 // Internal Imports *****************************************************
@@ -73,6 +74,9 @@ app.use(hpp());
 
 //Enable CORS ********************************************************
 app.use(cors());
+
+// CSRF Protection *****************************************************
+app.use(lusca.csrf());
 
 //Set Static Folder ****************************************************
 app.use(express.static(path.join(__dirname, 'public')));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "express-fileupload": "^1.4.0",
         "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^6.7.0",
+        "express-session": "^1.18.1",
         "helmet": "^7.0.0",
         "hpp": "^0.2.3",
         "jsonwebtoken": "^9.0.0",
+        "lusca": "^1.7.0",
         "mongoose": "^7.5.0",
         "morgan": "^1.10.0",
         "node-geocoder": "^4.2.0",
@@ -895,6 +897,51 @@
         "express": "^4 || ^5"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -1500,6 +1547,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -2068,6 +2126,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2466,6 +2533,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -2494,6 +2570,18 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {
@@ -3336,6 +3424,33 @@
       "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
       "requires": {}
     },
+    "express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "requires": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+          "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3758,6 +3873,14 @@
         "yallist": "^4.0.0"
       }
     },
+    "lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "requires": {
+        "tsscmp": "^1.0.5"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4152,6 +4275,11 @@
         "side-channel": "^1.0.6"
       }
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4456,6 +4584,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -4478,6 +4611,14 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,16 @@
     "express-fileupload": "^1.4.0",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.7.0",
+    "express-session": "^1.18.1",
     "helmet": "^7.0.0",
     "hpp": "^0.2.3",
     "jsonwebtoken": "^9.0.0",
+    "lusca": "^1.7.0",
     "mongoose": "^7.5.0",
     "morgan": "^1.10.0",
     "node-geocoder": "^4.2.0",
     "nodemailer": "^6.9.9",
     "slugify": "^1.6.6",
-    "xss-clean": "^0.1.4",
-    "lusca": "^1.7.0"
+    "xss-clean": "^0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node-geocoder": "^4.2.0",
     "nodemailer": "^6.9.9",
     "slugify": "^1.6.6",
-    "xss-clean": "^0.1.4"
+    "xss-clean": "^0.1.4",
+    "lusca": "^1.7.0"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/SOURAV-ROY/apiNodeJS/security/code-scanning/3](https://github.com/SOURAV-ROY/apiNodeJS/security/code-scanning/3)

To fix the problem, we need to add CSRF protection middleware to the application. The `lusca` library is a well-known middleware for CSRF protection in Express applications. We will:
1. Install the `lusca` package.
2. Import the `lusca` package in the `index.js` file.
3. Add the `lusca.csrf()` middleware to the application, ensuring it is placed after the session middleware and before any routes that handle state-changing requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
