### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/scripts/test_geocoder.js
+++ b/scripts/test_geocoder.js
@@ -12,7 +12,7 @@ const address = "Dhaka, Bangladesh";
 
 console.log(`Testing geocoder with provider: ${process.env.GEOCODER_PROVIDER}`);
 const apiKey = process.env.GEOCODER_API_KEY;
-console.log(`API Key length: ${apiKey ? apiKey.length : "undefined"}`);
+console.log(`API Key is ${apiKey ? "configured" : "not configured"}`);
 
 async function testGeocoder() {
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/SOURAV-ROY/apiNodeJS/security/code-scanning/17](https://github.com/SOURAV-ROY/apiNodeJS/security/code-scanning/17)

The best fix is to stop logging anything derived from `GEOCODER_API_KEY` and replace it with a non-sensitive presence check message.  
In `scripts/test_geocoder.js`, update the log at line 15 so it no longer includes `apiKey.length` or any interpolation of secret-derived data. Keep behavior intact by still indicating whether configuration exists, e.g. `"API Key is configured"` / `"API Key is not configured"`.

Concretely:
- Keep line 14 (`const apiKey = process.env.GEOCODER_API_KEY;`) as-is, since it is needed.
- Replace line 15 with a boolean-presence log that does not expose key content or metadata.

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test script output format for API key validation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->